### PR TITLE
Switch AI assistant to Claude Haiku 4.5

### DIFF
--- a/api/ai/draw.ts
+++ b/api/ai/draw.ts
@@ -347,7 +347,7 @@ CURRENT CANVAS STATE:
             "anthropic-version": "2023-06-01",
           },
           body: JSON.stringify({
-            model: "claude-sonnet-4-6",
+            model: "claude-haiku-4-5",
             max_tokens: 32768,
             system: contextPrompt,
             messages: claudeMessages,


### PR DESCRIPTION
Switches the AI Assistant's Claude API call from `claude-sonnet-4-6` to `claude-haiku-4-5`.

Single-line change in `api/ai/draw.ts` — the only model reference in the codebase. Nothing in the docs or config pins a model, so no other edits were needed.

### Notes

- **Context window drops 1M → 200K.** Fine for the chat + canvas-state prompt, but long conversations will hit the limit sooner.
- **`max_tokens: 32768` is still valid** — Haiku 4.5 caps output at 64K.
- The request is a raw `fetch` with no `thinking`, `effort`, or sampling params, so nothing else needed adjusting.

### Branch name

This lands on `revert-pr15-vite8`, whose name is left over from an unrelated revert that is already merged into `master`. Relative to `master` this branch now contains only the model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UuMVfWfigJ4Ej1QBQ1ZLW
